### PR TITLE
Support querying from vLLM server

### DIFF
--- a/benchmarking/query.sh
+++ b/benchmarking/query.sh
@@ -1,0 +1,1 @@
+python verl/benchmarking/query_vllm.py --model="hf_model" "Toulouse has twice as many sheep as Charleston. Charleston has 4 times as many sheep as Seattle. How many sheep do Toulouse, Charleston, and Seattle have together if Seattle has 20 sheep?"

--- a/benchmarking/query_vllm.py
+++ b/benchmarking/query_vllm.py
@@ -1,0 +1,81 @@
+import requests
+import argparse
+import sys
+
+def query_model(prompt: str, model: str, max_tokens: int, url: str):
+    """
+    Sends a prompt to the vLLM server and prints the text response.
+    """
+    # Define the HTTP headers and JSON payload
+    headers = {"Content-Type": "application/json"}
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+    }
+
+    try:
+        # Make the POST request
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+
+        data = response.json()
+        
+        # Extract and print the text from the first choice
+        if data.get("choices") and len(data["choices"]) > 0:
+            text_output = data["choices"][0].get("text", "Error: 'text' key not found in choice.").strip()
+            print(text_output)
+        else:
+            print("Error: 'choices' field not found or is empty in the response.", file=sys.stderr)
+            print("Full server response:", data, file=sys.stderr)
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error connecting to the vLLM server: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A simple command-line client for a vLLM server."
+    )
+    
+    parser.add_argument(
+        "prompt",
+        type=str,
+        help="The prompt to send to the model."
+    )
+    
+    parser.add_argument(
+        "-m", "--model",
+        type=str,
+        required=True,
+        help="The name of the model to query."
+    )
+    parser.add_argument(
+        "-t", "--max-tokens",
+        type=int,
+        default=512,
+        help="The maximum number of tokens to generate."
+    )
+    parser.add_argument(
+        "-u", "--url",
+        type=str,
+        default="http://localhost:8000/v1/completions",
+        help="The URL of the vLLM completions endpoint."
+    )
+
+    args = parser.parse_args()
+
+    prompt =  args.prompt  + 'Let\'s think step by step and output the final answer after \"####\".'
+
+    
+    query_model(
+        prompt=prompt,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        url=args.url
+    )

--- a/benchmarking/save_finetuned_model.py
+++ b/benchmarking/save_finetuned_model.py
@@ -1,0 +1,71 @@
+import torch
+import argparse
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+import os
+import sys
+from verl.utils.tokenizer import hf_tokenizer
+from verl.utils.model import update_model_config
+
+def convert_checkpoint(base_model: str, checkpoint_path: str, output_dir: str):
+    """
+    Loads a base model, applies a fine-tuned state_dict, and saves the result
+    in a vLLM-compatible Hugging Face format.
+    """
+
+    config = AutoConfig.from_pretrained(base_model, trust_remote_code=True)
+
+    tokenizer = hf_tokenizer(base_model, trust_remote_code=True)
+
+    override_config_kwargs = {
+        "bos_token_id": tokenizer.bos_token_id,
+        "eos_token_id": tokenizer.eos_token_id,
+        "pad_token_id": tokenizer.pad_token_id,
+    }
+    update_model_config(config, override_config_kwargs=override_config_kwargs)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.float32,
+        config=config,
+        trust_remote_code=True,
+    )
+
+    if not os.path.exists(checkpoint_path):
+        print(f"Error: Checkpoint file not found at '{checkpoint_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    state_dict = torch.load(checkpoint_path)
+
+    model.load_state_dict(state_dict)
+
+    os.makedirs(output_dir, exist_ok=True)
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    print(f"Conversion complete! Model saved to '{output_dir}'.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert a fine-tuned PyTorch state_dict to a full Hugging Face model directory."
+    )
+    parser.add_argument(
+        "--base_model",
+        type=str,
+        required=True,
+        help="The Hugging Face model ID of the base model (e.g., 'Qwen/Qwen2.5-0.5B-Instruct')."
+    )
+    parser.add_argument(
+        "--weights",
+        type=str,
+        required=True,
+        help="Path to the saved model."
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Directory to save the final, vLLM-compatible model."
+    )
+
+    args = parser.parse_args()
+    convert_checkpoint(args.base_model, args.weights, args.output_dir)


### PR DESCRIPTION
This PR contains two scripts. 

The first one `save_finetuned_model.py` saves the finetuned model's weights as a hugging face model (will integrate this into `save_checkpoint` later).

The second one `query_vllm.py` allows you to perform queries to the vLLM server and returns a readable output.
1. First start the vLLM server ` vllm serve <your model> --max-model-len=<max model length (2048)>`
2. After the server is started run the script like such 
`python query_vllm.py --model=<your model that you started the vLLM server with> "A robe takes 2 bolts of blue fiber and half that much white fiber. How many bolts in total does it take?"`

Also updated the benchmarking script. To test the accuracy of the finetuned model you can pass `--model=<finetuned model>` into the benchmarking script.

