### PR TITLE
FSDP support

### DIFF
--- a/actor_weights.txt
+++ b/actor_weights.txt
@@ -1,0 +1,1 @@
+{"model.embed_tokens.weight": 

--- a/actor_weights.txt
+++ b/actor_weights.txt
@@ -1,1 +1,0 @@
-{"model.embed_tokens.weight": 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -113,9 +113,9 @@ class RayResourcePool(ResourcePool):
         elif device_name == "tpu":
             device_name = "TPU"
 
-        bundle = {"CPU": 2}
+        bundle = {"CPU": 1}
         if self.use_accelerator:
-            bundle[device_name] = 2
+            bundle[device_name] = 4
             if self.accelerator_type is not None:
                 bundle[self.accelerator_type] = 1e-4
 
@@ -220,7 +220,7 @@ class RayClassWithInitArgs(ClassWithInitArgs):
         if use_accelerator and device_name == "npu":
             options["resources"] = {"NPU": num_accelerators}
         if use_accelerator and device_name == "tpu":
-            options["resources"] = {"TPU": num_accelerators}
+            options["resources"] = {"TPU": 4}
 
         if len(self._additional_resource) > 1:
             for k, v in self._additional_resource.items():

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -101,7 +101,6 @@ class RayResourcePool(ResourcePool):
         self.accelerator_type = accelerator_type
 
     def get_placement_groups(self, strategy="STRICT_PACK", name=None, device_name="tpu", num_accelerators=1):
-    def get_placement_groups(self, strategy="STRICT_PACK", name=None, device_name="tpu", num_accelerators=1):
         if self.pgs is not None:
             return self.pgs
 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -113,9 +113,9 @@ class RayResourcePool(ResourcePool):
         elif device_name == "tpu":
             device_name = "TPU"
 
-        bundle = {"CPU": self.max_colocate_count}
+        bundle = {"CPU": 2}
         if self.use_accelerator:
-            bundle[device_name] = num_accelerators
+            bundle[device_name] = 2
             if self.accelerator_type is not None:
                 bundle[self.accelerator_type] = 1e-4
 
@@ -123,7 +123,7 @@ class RayResourcePool(ResourcePool):
 
         lifetime = "detached" if self.detached else None
 
-        pgs = [placement_group(bundles=bundles, strategy=strategy, name=pg_name_prefix + str(idx), lifetime=lifetime) for idx, bundles in enumerate(pg_scheme)]
+        pgs = [placement_group(bundles=bundles, strategy="SPREAD", name=pg_name_prefix + str(idx), lifetime=lifetime) for idx, bundles in enumerate(pg_scheme)]
 
         ray.get([pg.ready() for pg in pgs])
 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -334,7 +334,7 @@ class RayWorkerGroup(WorkerGroup):
             strategy = "SPREAD"
             num_accelerators = self.n_tpus
 
-        pgs = resource_pool.get_placement_groups(strategy=strategy, device_name=self.device_name)
+        pgs = resource_pool.get_placement_groups(strategy=strategy, device_name=self.device_name, num_accelerators=num_accelerators)
         world_size = resource_pool.world_size
         self._world_size = world_size
         # cia.add_kwarg("_world_size", world_size)

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -284,11 +284,8 @@ actor_rollout_ref:
     # configs for FSDP via SPMD in PyTorch/XLA
     fsdp_spmd_config:
 
-
+      # number of TPUs to shard across
       n_tpus: 4
-
-
-
 
   # Reference model config.
   # Reference model will be enabled when actor.use_kl_loss or/and algorithm.use_kl_in_reward is/are True.

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -92,7 +92,7 @@ data:
 actor_rollout_ref:
 
   # Whether it's a hybrid engine, currently only supports hybrid engine
-  hybrid_engine: false
+  hybrid_engine: true
 
   # common configs for the model
   model:

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -150,7 +150,7 @@ actor_rollout_ref:
     strategy: xla
 
     # Whether to enable fsdp mode on TPU
-    enable_fsdp_xla: True
+    enable_fsdp_xla: False
     
     # Split each sample into sub-batches of this size for PPO
     ppo_mini_batch_size: 256

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -284,8 +284,6 @@ actor_rollout_ref:
     # configs for FSDP via SPMD in PyTorch/XLA
     fsdp_spmd_config:
 
-      # # Have actor and critic share the same resource pool
-      # colocate_actor_critic: True
 
       n_tpus: 4
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -92,7 +92,7 @@ data:
 actor_rollout_ref:
 
   # Whether it's a hybrid engine, currently only supports hybrid engine
-  hybrid_engine: true
+  hybrid_engine: false
 
   # common configs for the model
   model:
@@ -148,6 +148,9 @@ actor_rollout_ref:
   
     # fsdp, fsdp2, megatron or xla. fsdp backend used here.
     strategy: xla
+
+    # Whether to enable fsdp mode on TPU
+    enable_fsdp_xla: True
     
     # Split each sample into sub-batches of this size for PPO
     ppo_mini_batch_size: 256
@@ -277,6 +280,17 @@ actor_rollout_ref:
       # Only for FSDP1: FSDP1 configuration, prefetch the next forward-pass all-gather
       # before the current forward computation.
       forward_prefetch: False
+    
+    # configs for FSDP via SPMD in PyTorch/XLA
+    fsdp_spmd_config:
+
+      # # Have actor and critic share the same resource pool
+      # colocate_actor_critic: True
+
+      n_tpus: 4
+
+
+
 
   # Reference model config.
   # Reference model will be enabled when actor.use_kl_loss or/and algorithm.use_kl_in_reward is/are True.
@@ -332,6 +346,7 @@ actor_rollout_ref:
 
   # Rollout model config.
   rollout:
+    strategy: xla
 
     # actor_rollout_ref.rollout.name: hf/vllm/sglang.
     name: vllm
@@ -492,6 +507,9 @@ critic:
 
   # fsdp, fsdp2 or xla strategy used for critic model training
   strategy: xla 
+
+  # Whether to enable fsdp mode on TPU
+  enable_fsdp_xla: ${actor_rollout_ref.actor.enable_fsdp_xla}
 
   # optimizer configs
   optim:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -36,7 +36,7 @@ def run_ppo(config) -> None:
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         ray.init(
-            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true"}},
+            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true", "RAY_DEBUG":"1"}},
             num_cpus=config.ray_init.num_cpus,
         )
     
@@ -114,20 +114,45 @@ class TaskRunner:
         from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
 
         # Map roles to their corresponding remote worker classes.
-        role_worker_mapping = {
-            Role.ActorRollout: ray.remote(actor_rollout_cls),
-            Role.Critic: ray.remote(CriticWorker),
-        }
+        if config.actor_rollout_ref.actor.strategy == "xla" and config.actor_rollout_ref.actor.enable_fsdp_xla:
+            role_worker_mapping = {
+                Role.Actor: ray.remote(actor_rollout_cls),
+                Role.Rollout: ray.remote(actor_rollout_cls),
+                Role.Critic: ray.remote(CriticWorker),
+            }
+            
+            actor_critic_pool_id = "actor_critic_pool"
+            rollout_pool_id = "rollout_pool"
+
+            resource_pool_spec = {
+                actor_critic_pool_id: [config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+                rollout_pool_id: [config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+            }
+
+            mapping = {
+                Role.Actor: actor_critic_pool_id,
+                Role.Rollout: rollout_pool_id,
+                Role.Critic: actor_critic_pool_id,
+            }
+
+        else:
+            role_worker_mapping = {
+                Role.ActorRollout: ray.remote(actor_rollout_cls),
+                Role.Critic: ray.remote(CriticWorker),
+            }
 
         # Define the resource pool specification.
         # Map roles to the resource pool.
         global_pool_id = "global_pool"
+        actor_pool_id = "actor_pool"
+        critic_pool_id = "critic_pool"
         resource_pool_spec = {
-            global_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+            actor_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+            critic_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
         }
         mapping = {
-            Role.ActorRollout: global_pool_id,
-            Role.Critic: global_pool_id,
+            Role.ActorRollout: actor_pool_id,
+            Role.Critic: critic_pool_id,
         }
 
         # We should adopt a multi-source reward function here:

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -36,7 +36,7 @@ def run_ppo(config) -> None:
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         ray.init(
-            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true"}},
+            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true", "RAY_DEBUG":"1"}},
             num_cpus=config.ray_init.num_cpus,
         )
     

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -36,7 +36,7 @@ def run_ppo(config) -> None:
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         ray.init(
-            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true", "RAY_DEBUG":"1"}},
+            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true"}},
             num_cpus=config.ray_init.num_cpus,
         )
     
@@ -114,26 +114,43 @@ class TaskRunner:
         from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
 
         # Map roles to their corresponding remote worker classes.
-        role_worker_mapping = {
-            Role.Actor: ray.remote(actor_rollout_cls),
-            Role.Rollout: ray.remote(actor_rollout_cls),
-            Role.Critic: ray.remote(CriticWorker),
-        }
+        if config.actor_rollout_ref.actor.strategy == "xla" and config.actor_rollout_ref.actor.enable_fsdp_xla:
+            role_worker_mapping = {
+                Role.Actor: ray.remote(actor_rollout_cls),
+                Role.Rollout: ray.remote(actor_rollout_cls),
+                Role.Critic: ray.remote(CriticWorker),
+            }
+            
+            actor_critic_pool_id = "actor_critic_pool"
+            rollout_pool_id = "rollout_pool"
 
-        # Define the resource pool specification.
-        # Map roles to the resource pool.
-        global_pool_id = "global_pool"
-        actor_pool_id = "actor_pool"
-        critic_pool_id = "critic_pool"
-        resource_pool_spec = {
-            actor_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
-            critic_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
-        }
-        mapping = {
-            Role.Actor: actor_pool_id,
-            Role.Rollout: critic_pool_id,
-            Role.Critic: actor_pool_id,
-        }
+            resource_pool_spec = {
+                actor_critic_pool_id: [config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+                rollout_pool_id: [config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+            }
+
+            mapping = {
+                Role.Actor: actor_critic_pool_id,
+                Role.Rollout: rollout_pool_id,
+                Role.Critic: actor_critic_pool_id,
+            }
+
+        else:
+            role_worker_mapping = {
+                Role.ActorRollout: ray.remote(actor_rollout_cls),
+                Role.Critic: ray.remote(CriticWorker),
+            }
+
+            global_pool_id = "global_pool"
+        
+            resource_pool_spec = {
+                global_pool_id: [config.trainer.n_gpus_per_node if config.trainer.device == "cuda" else config.trainer.n_tpus_per_node] * config.trainer.nnodes,
+            }
+
+            mapping = {
+                Role.ActorRollout: global_pool_id,
+                Role.Critic: global_pool_id,
+            }
 
         # We should adopt a multi-source reward function here:
         # - for rule-based rm, we directly call a reward score

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -36,7 +36,7 @@ def run_ppo(config) -> None:
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         ray.init(
-            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true", "RAY_DEBUG":"1"}},
+            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true"}},
             num_cpus=config.ray_init.num_cpus,
         )
     

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -314,9 +314,10 @@ class RayPPOTrainer:
 
         self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
         assert self.hybrid_engine or config.actor_rollout_ref.actor.enable_fsdp_xla, "Currently, only support hybrid engine or fsdp with xla"
+        assert self.hybrid_engine or config.actor_rollout_ref.actor.enable_fsdp_xla, "Currently, only support hybrid engine or fsdp with xla"
 
-        # if self.hybrid_engine:
-        #     assert Role.ActorRollout in role_worker_mapping, f"{role_worker_mapping.keys()=}"
+        if self.hybrid_engine:
+            assert Role.ActorRollout in role_worker_mapping, f"{role_worker_mapping.keys()=}"
 
         self.role_worker_mapping = role_worker_mapping
         self.resource_pool_manager = resource_pool_manager
@@ -641,9 +642,9 @@ class RayPPOTrainer:
             print(f"test_gen_batch meta info: {test_gen_batch.meta_info}")
 
             # pad to be divisible by dp_size
-            test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.rollout_wg.world_size)
+            test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self._get_worker("rollout").world_size)
             if not self.async_rollout_mode:
-                test_output_gen_batch_padded = self.rollout_wg.generate_sequences(test_gen_batch_padded)
+                test_output_gen_batch_padded = self._get_worker("rollout").generate_sequences(test_gen_batch_padded)
             else:
                 self.async_rollout_manager.wake_up()
                 test_output_gen_batch_padded = self.async_rollout_manager.generate_sequences(test_gen_batch_padded)
@@ -720,22 +721,13 @@ class RayPPOTrainer:
 
         # create actor and rollout
         if self.hybrid_engine:
-            actor_resource_pool = self.resource_pool_manager.get_resource_pool(Role.Actor)
-            actor_cls = RayClassWithInitArgs(
-                cls=self.role_worker_mapping[Role.Actor],
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.ActorRollout)
+            actor_rollout_cls = RayClassWithInitArgs(
+                cls=self.role_worker_mapping[Role.ActorRollout],
                 config=self.config.actor_rollout_ref,
-                role="actor",
+                role="actor_rollout",
             )
-            self.resource_pool_to_cls[actor_resource_pool]["actor"] = actor_cls
-            
-            rollout_resource_pool = self.resource_pool_manager.get_resource_pool(Role.Rollout)
-            rollout_cls= RayClassWithInitArgs(
-                cls=self.role_worker_mapping[Role.Rollout],
-                config=self.config.actor_rollout_ref,
-                role="rollout",
-            )
-            self.resource_pool_to_cls[rollout_resource_pool]["rollout"] = rollout_cls 
-
+            self.resource_pool_to_cls[resource_pool]["actor_rollout"] = actor_rollout_cls
         else:
             actor_resource_pool = self.resource_pool_manager.get_resource_pool(Role.Actor)
             actor_cls = RayClassWithInitArgs(
@@ -781,7 +773,11 @@ class RayPPOTrainer:
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
-        
+
+        if self.config.actor_rollout_ref.actor.strategy == "xla":
+            wg_kwargs["enable_fsdp_xla"] = self.config.actor_rollout_ref.actor.enable_fsdp_xla
+            wg_kwargs["n_tpus"] = self.config.actor_rollout_ref.actor.fsdp_spmd_config.n_tpus
+
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             if len(class_dict) > 1:
                 # Multiple roles in the same resource pool, fuse them
@@ -810,11 +806,14 @@ class RayPPOTrainer:
 
         # we should create rollout at the end so that vllm can have a better estimation of kv cache memory
         if self.hybrid_engine:
+            self.actor_rollout_wg = all_wg["actor_rollout"]
+            self.actor_rollout_wg.init_model()
+        else:
             self.actor_wg = all_wg["actor"]
-        self.actor_wg.init_model()
+            self.actor_wg.init_model()
 
-        self.rollout_wg = all_wg["rollout"]
-        self.rollout_wg.init_model(actor_cls=self.actor_wg)
+            self.rollout_wg = all_wg["rollout"]
+            self.rollout_wg.init_model(actor_cls=self.actor_wg)
 
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
@@ -842,7 +841,7 @@ class RayPPOTrainer:
         max_actor_ckpt_to_keep = self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
         max_critic_ckpt_to_keep = self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
 
-        self.actor_wg.save_checkpoint(actor_local_path, actor_remote_path, self.global_steps, max_ckpt_to_keep=max_actor_ckpt_to_keep)
+        self._get_worker("actor").save_checkpoint(actor_local_path, actor_remote_path, self.global_steps, max_ckpt_to_keep=max_actor_ckpt_to_keep)
 
         if self.use_critic:
             critic_local_path = os.path.join(local_global_step_folder, "critic")
@@ -897,7 +896,7 @@ class RayPPOTrainer:
         actor_path = os.path.join(global_step_folder, "actor")
         critic_path = os.path.join(global_step_folder, "critic")
         # load actor
-        self.actor_wg.load_checkpoint(actor_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load)
+        self._get_worker("actor").load_checkpoint(actor_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load)
         # load critic
         if self.use_critic:
             self.critic_wg.load_checkpoint(critic_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load)
@@ -916,7 +915,7 @@ class RayPPOTrainer:
         attention_mask = batch.batch["attention_mask"]
         batch_size = attention_mask.shape[0]
         global_seqlen_lst = batch.batch["attention_mask"].view(batch_size, -1).sum(-1).tolist()  # (train_batch_size,)
-        world_size = self.actor_wg.world_size
+        world_size = self._get_worker("actor").world_size
         global_partition_lst = get_seqlen_balanced_partitions(global_seqlen_lst, k_partitions=world_size, equal_size=True)
         # reorder based on index. The data will be automatically equally partitioned by dispatch function
         global_idx = torch.tensor([j for partition in global_partition_lst for j in partition])
@@ -990,7 +989,7 @@ class RayPPOTrainer:
                     # generate a batch
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
+                            gen_batch_output = self._get_worker("rollout").generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
@@ -1002,7 +1001,7 @@ class RayPPOTrainer:
                         with _timer("gen_max", timing_raw):
                             gen_baseline_batch = deepcopy(gen_batch)
                             gen_baseline_batch.meta_info["do_sample"] = False
-                            gen_baseline_output = self.rollout_wg.generate_sequences(gen_baseline_batch)
+                            gen_baseline_output = self._get_worker("rollout").generate_sequences(gen_baseline_batch)
 
                             batch = batch.union(gen_baseline_output)
                             reward_baseline_tensor = self.reward_fn(batch)
@@ -1044,7 +1043,7 @@ class RayPPOTrainer:
 
                     # recompute old_log_probs
                     with _timer("old_log_prob", timing_raw):
-                        old_log_prob = self.actor_wg.compute_log_prob(batch)
+                        old_log_prob = self._get_worker("actor").compute_log_prob(batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
                         loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
@@ -1084,7 +1083,7 @@ class RayPPOTrainer:
                             if not self.ref_in_actor:
                                 ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
                             else:
-                                ref_log_prob = self.actor_wg.compute_ref_log_prob(batch)
+                                ref_log_prob = self._get_worker("actor").compute_ref_log_prob(batch)
                             batch = batch.union(ref_log_prob)
 
                     # compute values
@@ -1137,7 +1136,7 @@ class RayPPOTrainer:
                         # update actor
                         with _timer("update_actor", timing_raw):
                             batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
-                            actor_output = self.actor_wg.update_actor(batch)
+                            actor_output = self._get_worker("actor").update_actor(batch)
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -999,7 +999,7 @@ class RayPPOTrainer:
                             # Get the latest weights from the actor worker group
                             actor_weights = self.actor_wg.get_state_dict(gen_batch)
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights)
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -997,9 +997,9 @@ class RayPPOTrainer:
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
                             # Get the latest weights from the actor worker group
-                            actor_weights = self.actor_wg.get_state_dict()
+                            actor_weights = self.actor_wg.get_state_dict(gen_batch)
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights=actor_weights)
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -990,7 +990,6 @@ class RayPPOTrainer:
                     # generate a batch
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
-                            gen_batch.meta_info["step"] = self.global_steps
                             gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()
@@ -1138,7 +1137,6 @@ class RayPPOTrainer:
                         # update actor
                         with _timer("update_actor", timing_raw):
                             batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
-                            batch.meta_info["step"] = self.global_steps
                             actor_output = self.actor_wg.update_actor(batch)
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -981,10 +981,6 @@ class RayPPOTrainer:
                 timing_raw = {}
                 batch: DataProto = DataProto.from_single_dict(batch_dict)
 
-
-                testing = self.actor_wg.compute_log_prob(batch)
-                return
-
                 # pop those keys for generation
                 batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
                 non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -813,8 +813,8 @@ class RayPPOTrainer:
             self.actor_wg = all_wg["actor"]
         self.actor_wg.init_model()
 
-        # self.rollout_wg = all_wg["rollout"]
-        # self.rollout_wg.init_model(actor_cls=self.actor_wg)
+        self.rollout_wg = all_wg["rollout"]
+        self.rollout_wg.init_model(actor_cls=self.actor_wg)
 
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -643,7 +643,7 @@ class RayPPOTrainer:
             # pad to be divisible by dp_size
             test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.rollout_wg.world_size)
             if not self.async_rollout_mode:
-                test_output_gen_batch_padded = self.rollout_wg.generate_sequences(test_gen_batch_padded)[0]
+                test_output_gen_batch_padded = self.rollout_wg.generate_sequences(test_gen_batch_padded)
             else:
                 self.async_rollout_manager.wake_up()
                 test_output_gen_batch_padded = self.async_rollout_manager.generate_sequences(test_gen_batch_padded)
@@ -993,7 +993,7 @@ class RayPPOTrainer:
                             # Get the latest weights from the actor worker group
                             # actor_weights = self.actor_wg.get_state_dict()
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)[0]
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -781,12 +781,7 @@ class RayPPOTrainer:
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
-
-        breakpoint()
-        if self.config.actor_rollout_ref.actor.strategy == "xla":
-            wg_kwargs["enable_fsdp_xla"] = self.config.actor_rollout_ref.actor.enable_fsdp_xla
-            wg_kwargs["n_tpus"] = self.config.actor_rollout_ref.actor.fsdp_spmd_config.n_tpus
-
+        
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             if len(class_dict) > 1:
                 # Multiple roles in the same resource pool, fuse them

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -990,6 +990,7 @@ class RayPPOTrainer:
                     # generate a batch
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
+                            gen_batch.meta_info["step"] = self.global_steps
                             gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()
@@ -1137,6 +1138,7 @@ class RayPPOTrainer:
                         # update actor
                         with _timer("update_actor", timing_raw):
                             batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
+                            batch.meta_info["step"] = self.global_steps
                             actor_output = self.actor_wg.update_actor(batch)
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -999,7 +999,8 @@ class RayPPOTrainer:
                             # Get the latest weights from the actor worker group
                             actor_weights = self.actor_wg.get_state_dict(gen_batch)
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights)
+                            breakpoint()
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights[0])
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -643,7 +643,7 @@ class RayPPOTrainer:
             # pad to be divisible by dp_size
             test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.rollout_wg.world_size)
             if not self.async_rollout_mode:
-                test_output_gen_batch_padded = self.rollout_wg.generate_sequences(test_gen_batch_padded)
+                test_output_gen_batch_padded = self.rollout_wg.generate_sequences(test_gen_batch_padded)[0]
             else:
                 self.async_rollout_manager.wake_up()
                 test_output_gen_batch_padded = self.async_rollout_manager.generate_sequences(test_gen_batch_padded)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -990,9 +990,6 @@ class RayPPOTrainer:
                     # generate a batch
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
-                            # Get the latest weights from the actor worker group
-                            # actor_weights = self.actor_wg.get_state_dict()
-                            # Pass the weights to the rollout worker group for generation
                             gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)
                         else:
                             self.async_rollout_manager.wake_up()

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -814,13 +814,7 @@ class RayPPOTrainer:
         self.actor_wg.init_model()
 
         self.rollout_wg = all_wg["rollout"]
-            self.rollout_wg.init_model()
-        else:
-            self.actor_wg = all_wg["actor"]
-            self.actor_wg.init_model()
-
-            self.rollout_wg = all_wg["rollout"]
-            self.rollout_wg.init_model(actor_cls=self.actor_wg)
+        self.rollout_wg.init_model(actor_cls=self.actor_wg)
 
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
@@ -997,9 +991,9 @@ class RayPPOTrainer:
                     with _timer("gen", timing_raw):
                         if not self.async_rollout_mode:
                             # Get the latest weights from the actor worker group
-                            actor_weights = self.actor_wg.get_state_dict(gen_batch)
+                            # actor_weights = self.actor_wg.get_state_dict()
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights[0])[0]
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch)[0]
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -999,7 +999,7 @@ class RayPPOTrainer:
                             # Get the latest weights from the actor worker group
                             actor_weights = self.actor_wg.get_state_dict(gen_batch)
                             # Pass the weights to the rollout worker group for generation
-                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights[0])
+                            gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights[0])[0]
                         else:
                             self.async_rollout_manager.wake_up()
                             gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -813,8 +813,8 @@ class RayPPOTrainer:
             self.actor_wg = all_wg["actor"]
         self.actor_wg.init_model()
 
-        self.rollout_wg = all_wg["rollout"]
-        self.rollout_wg.init_model(actor_cls=self.actor_wg)
+        # self.rollout_wg = all_wg["rollout"]
+        # self.rollout_wg.init_model(actor_cls=self.actor_wg)
 
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -999,7 +999,6 @@ class RayPPOTrainer:
                             # Get the latest weights from the actor worker group
                             actor_weights = self.actor_wg.get_state_dict(gen_batch)
                             # Pass the weights to the rollout worker group for generation
-                            breakpoint()
                             gen_batch_output = self.rollout_wg.generate_sequences(gen_batch, actor_weights[0])
                         else:
                             self.async_rollout_manager.wake_up()

--- a/verl/utils/tpu_utils.py
+++ b/verl/utils/tpu_utils.py
@@ -1,5 +1,4 @@
 import torch
-from verl.utils.debug import GPUMemoryLogger
 
 class Tpu:
     """This is to simulate torch.tpu backend. 
@@ -62,6 +61,7 @@ def shard_input_data(batch_values):
 
 def conditional_gpu_logger(strategy, role, logger):
     """Returns GPUMemoryLogger decorator if not running on TPU."""
+    from verl.utils.debug import GPUMemoryLogger
     if strategy != "xla":
         return GPUMemoryLogger(role=role, logger=logger)
     else:

--- a/verl/utils/tpu_utils.py
+++ b/verl/utils/tpu_utils.py
@@ -1,4 +1,5 @@
 import torch
+from verl.utils.debug import GPUMemoryLogger
 
 class Tpu:
     """This is to simulate torch.tpu backend. 
@@ -61,7 +62,6 @@ def shard_input_data(batch_values):
 
 def conditional_gpu_logger(strategy, role, logger):
     """Returns GPUMemoryLogger decorator if not running on TPU."""
-    from verl.utils.debug import GPUMemoryLogger
     if strategy != "xla":
         return GPUMemoryLogger(role=role, logger=logger)
     else:

--- a/verl/utils/tpu_utils.py
+++ b/verl/utils/tpu_utils.py
@@ -50,3 +50,21 @@ class Tpu:
 
     def manual_seed(self, seed):
         self.torch_xla.manual_seed(seed)
+
+def shard_input_data(batch_values):
+    import torch_xla
+    import torch_xla.distributed.spmd as xs
+    for tensor in batch_values:
+        if not torch_xla._XLAC._get_xla_sharding_spec(tensor):
+            partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
+            xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
+
+def conditional_gpu_logger(strategy, role, logger):
+    """Returns GPUMemoryLogger decorator if not running on TPU."""
+    from verl.utils.debug import GPUMemoryLogger
+    if strategy != "xla":
+        return GPUMemoryLogger(role=role, logger=logger)
+    else:
+        def no_op_decorator(func):
+            return func
+        return no_op_decorator

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -345,23 +345,9 @@ class DataParallelPPOActor(BasePPOActor):
 
         return log_probs, entropys
     
-    def get_param_sum(self, step):
-        # Find a parameter to track
-        import json
-        with torch.no_grad():
-            sum_dict = {}
-            for name, param in self.actor_module.named_parameters():
-                sum_dict[name] = param.sum().item()
-
-            with open(f"/workspaces/parameters/parameter_values_{step}.sjon", "w") as file:
-                file.write(json.dumps(sum_dict, indent=4))
-
-            return sum_dict
-
     # @GPUMemoryLogger(role="dp actor", logger=logger)
-    def update_policy(self, data: DataProto, step):
+    def update_policy(self, data: DataProto):
         # make sure we are in training mode
-        self.get_param_sum(step)
         self.actor_module.train()
 
         temperature = data.meta_info["temperature"]  # temperature must be in the data.meta_info to avoid silent error
@@ -407,7 +393,6 @@ class DataParallelPPOActor(BasePPOActor):
 
                 self.actor_optimizer.zero_grad(set_to_none=True)
 
-                print("ACTOR LENGTH MICROBATCHES", len(micro_batches))
                 for data in micro_batches:
                     # Support all hardwares
                     if isinstance(data, DataProto):

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -304,7 +304,7 @@ class DataParallelPPOActor(BasePPOActor):
 
         for tensor in batch.values():
             if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in tensor.ndim)
+                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
                 xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
 
@@ -365,7 +365,7 @@ class DataParallelPPOActor(BasePPOActor):
 
         for tensor in batch.values():
             if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in tensor.ndim)
+                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
                 xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
 
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -271,6 +271,7 @@ class DataParallelPPOActor(BasePPOActor):
             self.actor_optimizer.step()
         return grad_norm
 
+    # @GPUMemoryLogger(role="dp actor", logger=logger)
     def compute_log_prob(self, data: DataProto, calculate_entropy=False) -> torch.Tensor:
         """Compute the log probability of the responses given input_ids, attention_mask and position_ids
 
@@ -343,7 +344,8 @@ class DataParallelPPOActor(BasePPOActor):
                 entropys = entropys[revert_indices]
 
         return log_probs, entropys
-    
+
+    # @GPUMemoryLogger(role="dp actor", logger=logger)
     def update_policy(self, data: DataProto):
         # make sure we are in training mode
         self.actor_module.train()

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -344,10 +344,24 @@ class DataParallelPPOActor(BasePPOActor):
                 entropys = entropys[revert_indices]
 
         return log_probs, entropys
+    
+    def get_param_sum(self, step):
+        # Find a parameter to track
+        import json
+        with torch.no_grad():
+            sum_dict = {}
+            for name, param in self.actor_module.named_parameters():
+                sum_dict[name] = param.sum().item()
+
+            with open(f"/workspaces/parameters/parameter_values_{step}.sjon", "w") as file:
+                file.write(json.dumps(sum_dict, indent=4))
+
+            return sum_dict
 
     # @GPUMemoryLogger(role="dp actor", logger=logger)
-    def update_policy(self, data: DataProto):
+    def update_policy(self, data: DataProto, step):
         # make sure we are in training mode
+        self.get_param_sum(step)
         self.actor_module.train()
 
         temperature = data.meta_info["temperature"]  # temperature must be in the data.meta_info to avoid silent error
@@ -393,6 +407,7 @@ class DataParallelPPOActor(BasePPOActor):
 
                 self.actor_optimizer.zero_grad(set_to_none=True)
 
+                print("ACTOR LENGTH MICROBATCHES", len(micro_batches))
                 for data in micro_batches:
                     # Support all hardwares
                     if isinstance(data, DataProto):
@@ -461,8 +476,7 @@ class DataParallelPPOActor(BasePPOActor):
                         else:
                             loss = policy_loss / self.gradient_accumulation
                         loss.backward()
-                        if self.device_name == "xla":
-                            torch_xla.sync()
+                        # self.torch_xla.sync()
                     data = {
                         "actor/pg_loss": pg_loss.detach().item(),
                         "actor/pg_clipfrac": pg_clipfrac.detach().item(),
@@ -478,9 +492,9 @@ class DataParallelPPOActor(BasePPOActor):
                 append_to_dict(metrics, data)
             if self.device_name == "xla":
                 torch_xla.sync()
-                torch_xla.core.xla_model.wait_device_ops()
+            self.torch_xla.core.xla_model.wait_device_ops()
         self.actor_optimizer.zero_grad(set_to_none=True)
         if self.device_name == "xla":
             torch_xla.sync()
-            torch_xla.core.xla_model.wait_device_ops()
+        self.torch_xla.core.xla_model.wait_device_ops()
         return metrics

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -35,7 +35,7 @@ from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches
 from verl.utils.torch_functional import logprobs_from_logits
 from verl.utils.ulysses import gather_outpus_and_unpad, ulysses_pad, ulysses_pad_and_slice_inputs
-from verl.utils.tpu import shard_input_data, conditional_gpu_logger
+from verl.utils.tpu_utils import shard_input_data, conditional_gpu_logger
 from verl.workers.actor import BasePPOActor
 
 if is_cuda_available:
@@ -273,7 +273,6 @@ class DataParallelPPOActor(BasePPOActor):
             self.actor_optimizer.step()
         return grad_norm
 
-    @conditional_gpu_logger(condition=self.config.strategy, role="dp actor", logger=logger)
     def compute_log_prob(self, data: DataProto, calculate_entropy=False) -> torch.Tensor:
         """Compute the log probability of the responses given input_ids, attention_mask and position_ids
 
@@ -347,7 +346,6 @@ class DataParallelPPOActor(BasePPOActor):
 
         return log_probs, entropys
     
-    @conditional_gpu_logger(condition=self.config.strategy, role="dp actor", logger=logger)
     def update_policy(self, data: DataProto):
         # make sure we are in training mode
         self.actor_module.train()

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -477,7 +477,6 @@ class DataParallelPPOActor(BasePPOActor):
                 append_to_dict(metrics, data)
             if self.device_name == "xla":
                 torch_xla.sync()
-                torch_xla.core.xla_model.wait_device_ops()
         self.actor_optimizer.zero_grad(set_to_none=True)
         if self.device_name == "xla":
             torch_xla.sync()

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -258,6 +258,8 @@ class DataParallelPPOCritic(BasePPOCritic):
 
                 print("CRITIC LENGTH MICROBATCHES", len(micro_batches))
 
+                print("CRITIC LENGTH MICROBATCHES", len(micro_batches))
+
                 for data in micro_batches:
                     # Support all devices
                     if isinstance(data, DataProto):
@@ -291,8 +293,7 @@ class DataParallelPPOCritic(BasePPOCritic):
                             loss = vf_loss / self.gradient_accumulation
 
                         loss.backward()
-                        if self.device_name == "xla":
-                            torch_xla.sync()
+                        # self.torch_xla.sync()
 
                     data = {
                         "critic/vf_loss": vf_loss.detach().item(),
@@ -309,9 +310,9 @@ class DataParallelPPOCritic(BasePPOCritic):
                 append_to_dict(metrics, data)
             if self.device_name == "xla":
                 torch_xla.sync()
-                torch_xla.core.xla_model.wait_device_ops()
+            self.torch_xla.core.xla_model.wait_device_ops()
         self.critic_optimizer.zero_grad(set_to_none=True)
         if self.device_name == "xla":
             torch_xla.sync()
-            torch_xla.core.xla_model.wait_device_ops()
+        self.torch_xla.core.xla_model.wait_device_ops()
         return metrics

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -175,7 +175,7 @@ class DataParallelPPOCritic(BasePPOCritic):
         batch = data.select(batch_keys=select_keys).batch
         for tensor in batch.values():
             if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in tensor.ndim)
+                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
                 xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
 
         use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
@@ -229,7 +229,7 @@ class DataParallelPPOCritic(BasePPOCritic):
         batch = data.select(batch_keys=select_keys).batch
         for tensor in batch.values():
             if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in tensor.ndim)
+                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
                 xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
 
 

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -165,6 +165,7 @@ class DataParallelPPOCritic(BasePPOCritic):
             self.critic_optimizer.step()
         return grad_norm
 
+    # @GPUMemoryLogger(role="dp critic", logger=logger)
     def compute_values(self, data: DataProto) -> torch.Tensor:
         self.critic_module.eval()
         micro_batch_size = data.meta_info["micro_batch_size"]
@@ -215,6 +216,7 @@ class DataParallelPPOCritic(BasePPOCritic):
         values = values * response_mask # Only action tokens have values
         return values
 
+    # @GPUMemoryLogger(role="dp critic", logger=logger)
     def update_critic(self, data: DataProto):
         # make sure we are in training mode
         self.critic_module.train()

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -35,7 +35,7 @@ from verl.utils.seqlen_balancing import (get_reverse_idx,
 from verl.utils.torch_functional import masked_mean
 from verl.utils.ulysses import (gather_outpus_and_unpad,
                                 ulysses_pad_and_slice_inputs)
-from verl.utils.tpu_utils import shard_input_data, conditional_gpu_logger
+from verl.utils.tpu import shard_input_data, conditional_gpu_logger
 from verl.workers.critic import BasePPOCritic
 
 if is_cuda_available:
@@ -167,16 +167,15 @@ class DataParallelPPOCritic(BasePPOCritic):
             self.critic_optimizer.step()
         return grad_norm
 
-    # @GPUMemoryLogger(role="dp critic", logger=logger)
+    @conditional_gpu_logger(condition=self.config.strategy, role="dp critic", logger=logger)
     def compute_values(self, data: DataProto) -> torch.Tensor:
         self.critic_module.eval()
         micro_batch_size = data.meta_info["micro_batch_size"]
         select_keys = ["responses", "input_ids", "attention_mask", "position_ids"]
         batch = data.select(batch_keys=select_keys).batch
-        for tensor in batch.values():
-            if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
-                xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
+
+        if self.config.enable_fsdp_xla:
+            shard_input_data(batch.values())
 
         use_dynamic_bsz = data.meta_info["use_dynamic_bsz"]
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
@@ -219,7 +218,7 @@ class DataParallelPPOCritic(BasePPOCritic):
         values = values * response_mask # Only action tokens have values
         return values
 
-    # @GPUMemoryLogger(role="dp critic", logger=logger)
+    @conditional_gpu_logger(condition=self.config.strategy, role="dp critic", logger=logger)
     def update_critic(self, data: DataProto):
         # make sure we are in training mode
         self.critic_module.train()
@@ -227,11 +226,9 @@ class DataParallelPPOCritic(BasePPOCritic):
 
         select_keys = ["input_ids", "responses", "attention_mask", "position_ids", "values", "returns"]
         batch = data.select(batch_keys=select_keys).batch
-        for tensor in batch.values():
-            if not self.torch_xla._XLAC._get_xla_sharding_spec(tensor):
-                partition_spec = tuple("fsdp" if i == 0 else None for i in range(tensor.ndim))
-                xs.mark_sharding(tensor, xs.get_global_mesh(), partition_spec)
-
+        
+        if self.config.enable_fsdp_xla:
+            shard_input_data(batch.values())
 
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
 

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -35,7 +35,7 @@ from verl.utils.seqlen_balancing import (get_reverse_idx,
 from verl.utils.torch_functional import masked_mean
 from verl.utils.ulysses import (gather_outpus_and_unpad,
                                 ulysses_pad_and_slice_inputs)
-from verl.utils.tpu import shard_input_data, conditional_gpu_logger
+from verl.utils.tpu_utils import shard_input_data, conditional_gpu_logger
 from verl.workers.critic import BasePPOCritic
 
 if is_cuda_available:
@@ -69,17 +69,13 @@ class DataParallelPPOCritic(BasePPOCritic):
         self.ulysses_sequence_parallel_size = self.config.get("ulysses_sequence_parallel_size", 1)
         self.device_name = get_device_name()
 
-        if self.device_name == "xla":
-            import torch_xla
-            self.torch_xla = torch_xla
-
-        # self.compute_values = conditional_gpu_logger(
-        #     strategy=self.config.strategy, role="dp critic", logger=logger
-        # )(self.compute_values)
+        self.compute_values = conditional_gpu_logger(
+            strategy=self.config.strategy, role="dp critic", logger=logger
+        )(self.compute_values)
         
-        # self.update_critic = conditional_gpu_logger(
-        #     strategy=self.config.strategy, role="dp critic", logger=logger
-        # )(self.update_critic)
+        self.update_critic = conditional_gpu_logger(
+            strategy=self.config.strategy, role="dp critic", logger=logger
+        )(self.update_critic)
 
     def _forward_micro_batch(self, micro_batch):
         response_length = micro_batch["responses"].size(-1)
@@ -167,7 +163,6 @@ class DataParallelPPOCritic(BasePPOCritic):
             self.critic_optimizer.step()
         return grad_norm
 
-    @conditional_gpu_logger(condition=self.config.strategy, role="dp critic", logger=logger)
     def compute_values(self, data: DataProto) -> torch.Tensor:
         self.critic_module.eval()
         micro_batch_size = data.meta_info["micro_batch_size"]
@@ -218,7 +213,6 @@ class DataParallelPPOCritic(BasePPOCritic):
         values = values * response_mask # Only action tokens have values
         return values
 
-    @conditional_gpu_logger(condition=self.config.strategy, role="dp critic", logger=logger)
     def update_critic(self, data: DataProto):
         # make sure we are in training mode
         self.critic_module.train()

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -302,7 +302,6 @@ class DataParallelPPOCritic(BasePPOCritic):
                 append_to_dict(metrics, data)
             if self.device_name == "xla":
                 torch_xla.sync()
-                torch_xla.core.xla_model.wait_device_ops()
         self.critic_optimizer.zero_grad(set_to_none=True)
         if self.device_name == "xla":
             torch_xla.sync()

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -149,7 +149,7 @@ class vLLMRollout(BaseRollout):
         self.inference_engine = LLM(
             model=model_path,
             enable_sleep_mode=config.enable_sleep_mode,
-            tensor_parallel_size=tensor_parallel_size,
+            tensor_parallel_size=2,
             distributed_executor_backend="external_launcher",
             dtype=config.dtype,
             enforce_eager=config.enforce_eager,

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -44,8 +44,8 @@ from vllm.worker.worker_base import WorkerWrapperBase
 
 from verl import DataProto
 from verl.third_party.vllm import vllm_version
-from verl.utils.debug import GPUMemoryLogger
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
+from verl.utils.tpu_utils import conditional_gpu_logger
 from verl.workers.rollout.base import BaseRollout
 
 logger = logging.getLogger(__file__)
@@ -193,6 +193,10 @@ class vLLMRollout(BaseRollout):
 
         self.pad_token_id = tokenizer.pad_token_id
 
+        self.generate_sequences = conditional_gpu_logger(
+            strategy=self.config.strategy, role="vllm rollout spmd", logger=logger
+        )(self.generate_sequences)
+
     @contextmanager
     def update_sampling_params(self, **kwargs):
         # update sampling params
@@ -209,7 +213,6 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
-    @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -213,6 +213,7 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
+    # @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -45,7 +45,7 @@ from vllm.worker.worker_base import WorkerWrapperBase
 from verl import DataProto
 from verl.third_party.vllm import vllm_version
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
-from verl.utils.tpu import conditional_gpu_logger
+from verl.utils.tpu_utils import conditional_gpu_logger
 from verl.workers.rollout.base import BaseRollout
 
 logger = logging.getLogger(__file__)
@@ -213,7 +213,6 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
-    @conditional_gpu_logger(condition=self.config.strategy, role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -45,7 +45,7 @@ from vllm.worker.worker_base import WorkerWrapperBase
 from verl import DataProto
 from verl.third_party.vllm import vllm_version
 from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
-from verl.utils.tpu_utils import conditional_gpu_logger
+from verl.utils.tpu import conditional_gpu_logger
 from verl.workers.rollout.base import BaseRollout
 
 logger = logging.getLogger(__file__)
@@ -213,7 +213,7 @@ class vLLMRollout(BaseRollout):
         for key, value in old_sampling_params_args.items():
             setattr(self.sampling_params, key, value)
 
-    # @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
+    @conditional_gpu_logger(condition=self.config.strategy, role="vllm rollout spmd", logger=logger)
     @torch.no_grad()
     def generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
         # rebuild vllm cache engine

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -149,7 +149,7 @@ class vLLMRollout(BaseRollout):
         self.inference_engine = LLM(
             model=model_path,
             enable_sleep_mode=config.enable_sleep_mode,
-            tensor_parallel_size=2,
+            tensor_parallel_size=tensor_parallel_size,
             distributed_executor_backend="external_launcher",
             dtype=config.dtype,
             enforce_eager=config.enforce_eager,

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -341,7 +341,7 @@ class ActorRolloutRefWorker(Worker):
 
         return output
 
-    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    @register(dispatch_mode=Dispatch.ALL_TO_ALL)
     def generate_sequences(self, prompts: DataProto, actor_weights=None):
         # Support all hardwares
         prompts = prompts.to(get_torch_device().current_device())
@@ -357,8 +357,8 @@ class ActorRolloutRefWorker(Worker):
 
         with _timer("generate_sequences", timing_generate):
             print("ACTOR WEIGHTS IS NONE?")
-            print(actor_weights)
-            params = actor_weights if actor_weights is not None else self.actor_module_fsdp.state_dict()
+            print(actor_weights is not None)
+            params = actor_weights.non_tensor_batch["actor_weights"] if actor_weights is not None else self.actor_module_fsdp.state_dict()
             params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -358,8 +358,7 @@ class ActorRolloutRefWorker(Worker):
         with _timer("generate_sequences", timing_generate):
             print("ACTOR WEIGHTS IS NONE?")
             print(actor_weights is not None)
-            params = actor_weights.non_tensor_batch["actor_weights"] if actor_weights is not None else self.actor_module_fsdp.state_dict()
-            params = convert_weight_keys(params, actor_weights.non_tensor_batch["actor"] if actor_weights is not None else self.actor_module_fsdp)
+            params = actor_weights.non_tensor_batch["actor_weights"]
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
             # Create a list to hold the prepared parameters
@@ -379,10 +378,11 @@ class ActorRolloutRefWorker(Worker):
     def get_state_dict(self, data: DataProto):
         output = DataProto()
         weights = self.actor_module_fsdp.state_dict()
+        weights = convert_weight_keys(weights, self.actor_module_fsdp)
+
         for k, v in weights.items():
             weights[k] = v.cpu()
         output.non_tensor_batch["actor_weights"] = weights
-        output.non_tensor_batch["actor"] = self.actor_module_fsdp
 
         return output   
     

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -359,7 +359,7 @@ class ActorRolloutRefWorker(Worker):
             print("ACTOR WEIGHTS IS NONE?")
             print(actor_weights is not None)
             params = actor_weights.non_tensor_batch["actor_weights"] if actor_weights is not None else self.actor_module_fsdp.state_dict()
-            params = convert_weight_keys(params, self.actor_module_fsdp)
+            params = convert_weight_keys(params, actor_weights.non_tensor_batch["actor"] if actor_weights is not None else self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
             # Create a list to hold the prepared parameters
@@ -382,6 +382,7 @@ class ActorRolloutRefWorker(Worker):
         for k, v in weights.items():
             weights[k] = v.cpu()
         output.non_tensor_batch["actor_weights"] = weights
+        output.non_tensor_batch["actor"] = self.actor_module_fsdp
 
         return output   
     

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -54,9 +54,26 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 def custom_shard_output_impl(output, mesh):
     import torch_xla
     real_output = None
-    if isinstance(output, torch.Tensor):
-        real_output = output
-    elif isinstance(output, CausalLMOutputWithPast):
+    if isinstance(output, CausalLMOutputWithPast):
+        real_output = output.logits
+    elif isinstance(output, TokenClassifierOutput):
+          real_output = output.logits
+   
+    if real_output is None:
+        raise RuntimeError(
+            f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
+        )
+
+    print("prepare spmd partition spec", _prepare_spmd_partition_spec(real_output))
+
+    if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
+        xs.mark_sharding(
+            real_output, mesh, ("fdsp", None, None))
+
+def custom_shard_output_impl(output, mesh):
+    import torch_xla
+    real_output = None
+    if isinstance(output, CausalLMOutputWithPast):
         real_output = output.logits
     elif isinstance(output, TokenClassifierOutput):
           real_output = output.logits
@@ -71,34 +88,12 @@ def custom_shard_output_impl(output, mesh):
             f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
         )
 
+    print("prepare spmd partition spec", _prepare_spmd_partition_spec(real_output))
+
     if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
         xs.mark_sharding(
             real_output, mesh,
             _prepare_spmd_partition_spec(real_output))
-
-def custom_shard_output_impl(output, mesh):
-    import torch_xla
-    real_output = None
-    if isinstance(output, torch.Tensor):
-        real_output = output
-    elif isinstance(output, CausalLMOutputWithPast):
-        real_output = output.logits
-    elif isinstance(output, TokenClassifierOutput):
-          real_output = output.logits
-    elif isinstance(output, tuple):
-        real_output = output[0] if isinstance(output[0], torch.Tensor) else None
-        warnings.warn(
-            f"The output is a tuple, but only the first element is sharded. If this is not intended, please provide your own shard_output callable. {len(output)}    {real_output.shape}"
-        )
-   
-    if real_output is None:
-        raise RuntimeError(
-            f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
-        )
-
-    if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
-        xs.mark_sharding(
-            real_output, mesh, ("fsdp", None, None))
 
 
 class ActorRolloutRefWorker(Worker):
@@ -348,11 +343,12 @@ class ActorRolloutRefWorker(Worker):
     def update_actor(self, data: DataProto):
         # Support all hardwares
         data = data.to(get_torch_device().current_device())  # data will to device with each micro batch on actor.update_policy
+        step = data.meta_info["step"]
         assert self._is_actor
 
         # perform training
         with Timer(name="update_policy", logger=None) as timer:
-            metrics = self.actor.update_policy(data=data)
+            metrics = self.actor.update_policy(data=data, step=step)
         # delta_time = timer.last
         # global_num_tokens = data.meta_info["global_token_num"]
         # estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
@@ -392,6 +388,15 @@ class ActorRolloutRefWorker(Worker):
                 params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
 
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
+
+            import json
+            with torch.no_grad():
+                sum_dict = {}
+                for name, param in model.named_parameters():
+                    sum_dict[name] = param.sum().item()
+
+                with open(f"/workspaces/llm_parameters/parameter_values_{prompts.meta_info["step"]}.json", "w") as file:
+                    file.write(json.dumps(sum_dict, indent=4))
 
             # Create a list to hold the prepared parameters
             prepared_params = []

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -384,8 +384,8 @@ class ActorRolloutRefWorker(Worker):
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
 
-        for k, v in weights.items():
-            weights[k] = v.cpu()
+        # for k, v in weights.items():
+        #     weights[k] = v.cpu()
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -432,10 +432,8 @@ class ActorRolloutRefWorker(Worker):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=True)
     def get_state_dict(self):
         assert self._is_actor
-        self.actor_module_fsdp.to("cpu")
         params = self.actor_module_fsdp.state_dict()
         params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
-        self.actor_module_fsdp.to('xla')
         return params
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -54,10 +54,17 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 def custom_shard_output_impl(output, mesh):
     import torch_xla
     real_output = None
-    if isinstance(output, CausalLMOutputWithPast):
+    if isinstance(output, torch.Tensor):
+        real_output = output
+    elif isinstance(output, CausalLMOutputWithPast):
         real_output = output.logits
     elif isinstance(output, TokenClassifierOutput):
           real_output = output.logits
+    elif isinstance(output, tuple):
+        real_output = output[0] if isinstance(output[0], torch.Tensor) else None
+        warnings.warn(
+            f"The output is a tuple, but only the first element is sharded. If this is not intended, please provide your own shard_output callable. {len(output)}    {real_output.shape}"
+        )
    
     if real_output is None:
         raise RuntimeError(

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -384,11 +384,11 @@ class ActorRolloutRefWorker(Worker):
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
         with open("actor_weights.txt", "a") as file:
-            file.write(weights)
+            file.write(str(weights))
         for k, v in weights.items():
             weights[k] = v.cpu()
         with open("actor_weights_cpu.txt", "a") as file:
-            file.write(weights)
+            file.write(str(weights))
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -312,7 +312,6 @@ class ActorRolloutRefWorker(Worker):
             self.flops_counter = FlopsCounter(self.actor_model_config)
         
         self.actor_wg = actor_cls
-
         #TODO: create a checkpoint manager to allow loading checkpoints for rollout
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -358,9 +357,6 @@ class ActorRolloutRefWorker(Worker):
         timing_generate = {}
 
         with _timer("generate_sequences", timing_generate):
-            # print("ACTOR WEIGHTS IS NONE?")
-            # print(actor_weights is not None)
-            # breakpoint()
             if self.actor_wg is not None:
                 params = self.actor_wg.get_state_dict()[0]
             else:
@@ -385,18 +381,6 @@ class ActorRolloutRefWorker(Worker):
     def get_state_dict(self):
         assert self._is_actor
         return self.actor_module_fsdp.state_dict()
-        # output = DataProto()
-        # weights = self.actor_module_fsdp.state_dict()
-        # weights = convert_weight_keys(weights, self.actor_module_fsdp)
-        # with open("/workspaces/actor_weights_multi_tpu.txt", "a") as file:
-        #     file.write(str(weights))
-        # for k, v in weights.items():
-        #     weights[k] = v.cpu()
-        # with open("/workspaces/actor_weights_cpu_multi_tpu.txt", "a") as file:
-        #     file.write(str(weights))
-        # output.non_tensor_batch["actor_weights"] = weights
-
-        # return output   
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -252,6 +252,7 @@ class ActorRolloutRefWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self, actor_cls=None):
+    def init_model(self, actor_cls=None):
         from verl.workers.actor import DataParallelPPOActor
 
         # This is used to import external_lib into the huggingface systems
@@ -311,6 +312,7 @@ class ActorRolloutRefWorker(Worker):
             self.flops_counter = FlopsCounter(self.actor_model_config)
         
         self.actor_wg = actor_cls
+
         #TODO: create a checkpoint manager to allow loading checkpoints for rollout
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
@@ -341,8 +343,8 @@ class ActorRolloutRefWorker(Worker):
 
         return output
 
-    @register(dispatch_mode=Dispatch.ALL_TO_ALL)
-    def generate_sequences(self, prompts: DataProto, actor_weights=None):
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def generate_sequences(self, prompts: DataProto):
         # Support all hardwares
         prompts = prompts.to(get_torch_device().current_device())
 
@@ -356,13 +358,14 @@ class ActorRolloutRefWorker(Worker):
         timing_generate = {}
 
         with _timer("generate_sequences", timing_generate):
-            print("ACTOR WEIGHTS IS NONE?")
-            print(actor_weights is not None)
-            if actor_weights is not None:
-                params = actor_weights.non_tensor_batch["actor_weights"]
+            # print("ACTOR WEIGHTS IS NONE?")
+            # print(actor_weights is not None)
+            # breakpoint()
+            if self.actor_wg is not None:
+                params = self.actor_wg.get_state_dict()[0]
             else:
                 params = self.actor_module_fsdp.state_dict()
-                params = convert_weight_keys(params, self.actor_module_fsdp)
+            params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
             # Create a list to hold the prepared parameters
@@ -378,20 +381,22 @@ class ActorRolloutRefWorker(Worker):
         get_torch_device().empty_cache()
         return output
     
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def get_state_dict(self, data: DataProto):
-        output = DataProto()
-        weights = self.actor_module_fsdp.state_dict()
-        weights = convert_weight_keys(weights, self.actor_module_fsdp)
-        with open("actor_weights.txt", "a") as file:
-            file.write(str(weights))
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=True)
+    def get_state_dict(self):
+        assert self._is_actor
+        return self.actor_module_fsdp.state_dict()
+        # output = DataProto()
+        # weights = self.actor_module_fsdp.state_dict()
+        # weights = convert_weight_keys(weights, self.actor_module_fsdp)
+        # with open("/workspaces/actor_weights_multi_tpu.txt", "a") as file:
+        #     file.write(str(weights))
         # for k, v in weights.items():
         #     weights[k] = v.cpu()
-        # with open("actor_weights_cpu.txt", "a") as file:
+        # with open("/workspaces/actor_weights_cpu_multi_tpu.txt", "a") as file:
         #     file.write(str(weights))
-        output.non_tensor_batch["actor_weights"] = weights
+        # output.non_tensor_batch["actor_weights"] = weights
 
-        return output   
+        # return output   
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -383,9 +383,12 @@ class ActorRolloutRefWorker(Worker):
         output = DataProto()
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
-
+        with open("/workspaces/logging/actor_weights.txt", "w") as file:
+            json.dump(weights, file)
         for k, v in weights.items():
             weights[k] = v.cpu()
+        with open("/workspaces/logging/actor_weights_cpu.txt", "w") as file:
+            json.dump(weights, file)
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -71,8 +71,6 @@ def custom_shard_output_impl(output, mesh):
             f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
         )
 
-    print("prepare spmd partition spec", _prepare_spmd_partition_spec(real_output))
-
     if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
         xs.mark_sharding(
             real_output, mesh, ("fsdp", None, None))
@@ -350,12 +348,11 @@ class ActorRolloutRefWorker(Worker):
     def update_actor(self, data: DataProto):
         # Support all hardwares
         data = data.to(get_torch_device().current_device())  # data will to device with each micro batch on actor.update_policy
-        step = data.meta_info["step"]
         assert self._is_actor
 
         # perform training
         with Timer(name="update_policy", logger=None) as timer:
-            metrics = self.actor.update_policy(data=data, step=step)
+            metrics = self.actor.update_policy(data=data)
         # delta_time = timer.last
         # global_num_tokens = data.meta_info["global_token_num"]
         # estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
@@ -395,15 +392,6 @@ class ActorRolloutRefWorker(Worker):
                 params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
 
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
-
-            import json
-            with torch.no_grad():
-                sum_dict = {}
-                for name, param in model.named_parameters():
-                    sum_dict[name] = param.sum().item()
-
-                with open(f"/workspaces/llm_parameters/parameter_values_{prompts.meta_info["step"]}.json", "w") as file:
-                    file.write(json.dumps(sum_dict, indent=4))
 
             # Create a list to hold the prepared parameters
             prepared_params = []

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -427,8 +427,10 @@ class ActorRolloutRefWorker(Worker):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=True)
     def get_state_dict(self):
         assert self._is_actor
+        self.actor_module_fsdp.to("cpu")
         params = self.actor_module_fsdp.state_dict()
         params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
+        self.actor_module_fsdp.to('xla')
         return params
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -375,7 +375,7 @@ class ActorRolloutRefWorker(Worker):
         get_torch_device().empty_cache()
         return output
     
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL, execute_mode=Execute.RANK_ZERO)
+    @register()
     def get_state_dict(self):
         return self.actor_module_fsdp.state_dict()
     
@@ -384,24 +384,22 @@ class ActorRolloutRefWorker(Worker):
     def compute_log_prob(self, data: DataProto):
         assert self._is_actor
 
-        print("RUNNING COMPUTE LOG PROBS")
-
         output = data
-        # # Support all hardwares
-        # data = data.to(get_torch_device().current_device())
-        # # we should always recompute old_log_probs when it is HybridEngine
-        # data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
-        # data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
-        # data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
-        # data.meta_info["temperature"] = self.config.rollout.temperature
-        # # perform recompute log_prob
-        # output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
-        # output = DataProto.from_dict(
-        #     tensors={"old_log_probs": output, "entropys": entropys},
-        #     meta_info={"temperature": self.config.rollout.temperature},
-        # )
+        # Support all hardwares
+        data = data.to(get_torch_device().current_device())
+        # we should always recompute old_log_probs when it is HybridEngine
+        data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
+        data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
+        data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
+        data.meta_info["temperature"] = self.config.rollout.temperature
+        # perform recompute log_prob
+        output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
+        output = DataProto.from_dict(
+            tensors={"old_log_probs": output, "entropys": entropys},
+            meta_info={"temperature": self.config.rollout.temperature},
+        )
 
-        # output = output.to("cpu")
+        output = output.to("cpu")
 
         return output
 

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -41,12 +41,37 @@ import numpy as np
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from torch_xla.experimental.spmd_fully_sharded_data_parallel import SpmdFullyShardedDataParallel as FSDPv2
+from torch_xla.experimental.spmd_fully_sharded_data_parallel import _prepare_spmd_partition_spec
 from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
 import functools
 from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+def shard_output_with_causal_lm(output, mesh):
+    import torch_xla
+    real_output = None
+    if isinstance(output, torch.Tensor):
+        real_output = output
+    elif isinstance(output, CausalLMOutputWithPast):
+        real_output = output.logits
+    elif isinstance(output, tuple):
+        real_output = output[0] if isinstance(output[0], torch.Tensor) else None
+        warnings.warn(
+            "The output is a tuple, but only the first element is sharded. If this is not intended, please provide your own shard_output callable."
+        )
+    
+    if real_output is None:
+        raise RuntimeError(
+            f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
+        )
+
+    if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
+        xs.mark_sharding(
+            real_output, mesh,
+            _prepare_spmd_partition_spec(real_output))
 
 def custom_shard_output_impl(output, mesh):
     import torch_xla
@@ -196,7 +221,7 @@ class ActorRolloutRefWorker(Worker):
                     Qwen2DecoderLayer
                 },
             )
-            actor_module = FSDPv2(actor_module, auto_wrap_policy=auto_wrap_policy)
+            actor_module = FSDPv2(actor_module, auto_wrap_policy=auto_wrap_policy, shard_output=shard_output_with_causal_lm)
 
         if role == "actor" and optim_config is not None:
             from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -18,6 +18,7 @@ The main entry point to run the PPO algorithm
 import logging
 import os
 import warnings
+import json
 
 import psutil
 import torch
@@ -26,7 +27,7 @@ from omegaconf import DictConfig
 
 from verl import DataProto
 from verl.single_controller.base import Worker
-from verl.single_controller.base.decorator import Dispatch, register
+from verl.single_controller.base.decorator import Dispatch, register, Execute
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.debug.performance import _timer, reduce_timing
 from verl.utils.device import get_device_name, get_torch_device
@@ -35,9 +36,43 @@ from verl.utils.fs import copy_to_local
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import convert_weight_keys
 from torch.distributed.tensor import DTensor
+import numpy as np
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from torch_xla.experimental.spmd_fully_sharded_data_parallel import SpmdFullyShardedDataParallel as FSDPv2
+from torch_xla.experimental.spmd_fully_sharded_data_parallel import _prepare_spmd_partition_spec
+from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
+import functools
+from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.modeling_outputs import TokenClassifierOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+def custom_shard_output_impl(output, mesh):
+    import torch_xla
+    real_output = None
+    if isinstance(output, torch.Tensor):
+        real_output = output
+    elif isinstance(output, CausalLMOutputWithPast):
+        real_output = output.logits
+    elif isinstance(output, TokenClassifierOutput):
+          real_output = output.logits
+    elif isinstance(output, tuple):
+        real_output = output[0] if isinstance(output[0], torch.Tensor) else None
+        warnings.warn(
+            f"The output is a tuple, but only the first element is sharded. If this is not intended, please provide your own shard_output callable. {len(output)}    {real_output.shape}"
+        )
+   
+    if real_output is None:
+        raise RuntimeError(
+            f"The output type is not supported: {type(output)}. Please provide your own shard_output callable."
+        )
+
+    if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
+        xs.mark_sharding(
+            real_output, mesh, ("fsdp", None, None))
 
 
 class ActorRolloutRefWorker(Worker):
@@ -71,7 +106,7 @@ class ActorRolloutRefWorker(Worker):
             if self.config.actor.ppo_micro_batch_size_per_gpu is not None:
                 assert self.config.actor.ppo_mini_batch_size % self.config.actor.ppo_micro_batch_size_per_gpu == 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
                 assert self.config.actor.ppo_mini_batch_size // self.config.actor.ppo_micro_batch_size_per_gpu > 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be larger than ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
-
+            
         # normalize rollout config
         if self._is_rollout and self.config.rollout.log_prob_micro_batch_size is not None:
             self.config.rollout.log_prob_micro_batch_size_per_gpu = self.config.rollout.log_prob_micro_batch_size
@@ -142,9 +177,23 @@ class ActorRolloutRefWorker(Worker):
         actor_module.to(get_torch_device().current_device())
 
         actor_module.to(torch_dtype)
-
-        if self.rank == 0:
-            print_model_size(actor_module)
+        
+        if self._is_actor and self.config.actor.enable_fsdp_xla:
+            xr.use_spmd()
+            num_devices = xr.global_runtime_device_count()
+            mesh_shape = (num_devices, 1)
+            device_ids = np.array(range(num_devices))
+            # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
+            mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
+            xs.set_global_mesh(mesh)
+            
+            auto_wrap_policy = functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={
+                    Qwen2DecoderLayer
+                },
+            )
+            actor_module = FSDPv2(actor_module, auto_wrap_policy=auto_wrap_policy, shard_output=custom_shard_output_impl)
 
         if role == "actor" and optim_config is not None:
             from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
@@ -182,6 +231,9 @@ class ActorRolloutRefWorker(Worker):
         return actor_module, actor_optimizer, actor_lr_scheduler, actor_model_config
 
     def _build_rollout(self, trust_remote_code=False):
+
+        infer_tp = self.config.rollout.tensor_model_parallel_size
+        assert self.world_size % infer_tp == 0, f"rollout world_size: {self.world_size} is not divisible by infer_tp: {infer_tp}"
         rollout_name = self.config.rollout.name
         assert rollout_name == "vllm"
 
@@ -198,7 +250,7 @@ class ActorRolloutRefWorker(Worker):
         return rollout
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def init_model(self):
+    def init_model(self, actor_cls=None):
         from verl.workers.actor import DataParallelPPOActor
 
         # This is used to import external_lib into the huggingface systems
@@ -256,26 +308,28 @@ class ActorRolloutRefWorker(Worker):
 
         if self._is_actor:
             self.flops_counter = FlopsCounter(self.actor_model_config)
-
+        
+        self.actor_wg = actor_cls
         #TODO: create a checkpoint manager to allow loading checkpoints for rollout
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_actor(self, data: DataProto):
         # Support all hardwares
         data = data.to(get_torch_device().current_device())  # data will to device with each micro batch on actor.update_policy
-
         assert self._is_actor
 
         # perform training
         with Timer(name="update_policy", logger=None) as timer:
             metrics = self.actor.update_policy(data=data)
-        delta_time = timer.last
-        global_num_tokens = data.meta_info["global_token_num"]
-        estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
-        metrics["perf/mfu/actor"] = estimated_flops * self.config.actor.ppo_epochs / promised_flops / self.world_size
-        metrics["perf/max_memory_allocated_gb"] = get_torch_device().max_memory_allocated() / (1024**3)
-        metrics["perf/max_memory_reserved_gb"] = get_torch_device().max_memory_reserved() / (1024**3)
-        metrics["perf/cpu_memory_used_gb"] = psutil.virtual_memory().used / (1024**3)
+        
+        if not self.config.actor.enable_fsdp_xla:
+            delta_time = timer.last
+            global_num_tokens = data.meta_info["global_token_num"]
+            estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
+            metrics["perf/mfu/actor"] = estimated_flops * self.config.actor.ppo_epochs / promised_flops / self.world_size
+            metrics["perf/max_memory_allocated_gb"] = get_torch_device().max_memory_allocated() / (1024**3)
+            metrics["perf/max_memory_reserved_gb"] = get_torch_device().max_memory_reserved() / (1024**3)
+            metrics["perf/cpu_memory_used_gb"] = psutil.virtual_memory().used / (1024**3)
 
         lr = self.actor_lr_scheduler.get_last_lr()[0]
         metrics["actor/lr"] = lr
@@ -301,10 +355,17 @@ class ActorRolloutRefWorker(Worker):
         timing_generate = {}
 
         with _timer("generate_sequences", timing_generate):
-            params = self.actor_module_fsdp.state_dict()
-            params = convert_weight_keys(params, self.actor_module_fsdp)
+            if self.actor_wg is not None:
+                params = self.actor_wg.get_state_dict()[0]
+            else:
+                params = self.actor_module_fsdp.state_dict()
+                params = convert_weight_keys(params, self.actor_module_fsdp)
+
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
-            loaded_params = model.load_weights(((name, param.to(self.device_name, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param) for name, param in params.items()))
+
+            # Create a list to hold the prepared parameters
+            prepared_params = ((name, param.to(self.device_name, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param) for name, param in params.items())
+            loaded_params = model.load_weights(((prepared_param[0].replace("_orig_module.",""), prepared_param[1]) for prepared_param in prepared_params))
             logger.info(f"vLLM load weights, loaded_params: {len(loaded_params) if loaded_params else -1}")
             output = self.rollout.generate_sequences(prompts=prompts)
 
@@ -314,11 +375,17 @@ class ActorRolloutRefWorker(Worker):
         # clear kv cache
         get_torch_device().empty_cache()
         return output
-
+    
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=True)
+    def get_state_dict(self):
+        assert self._is_actor
+        params = self.actor_module_fsdp.state_dict()
+        params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
+        return params
+    
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):
         assert self._is_actor
-
         # Support all hardwares
         data = data.to(get_torch_device().current_device())
         # we should always recompute old_log_probs when it is HybridEngine
@@ -437,8 +504,22 @@ class CriticWorker(Worker):
         # some parameters may not in torch_dtype
         critic_module.to(torch_dtype)
 
-        if self.rank == 0:
-            print_model_size(critic_module)
+        if self.config.enable_fsdp_xla:
+            xr.use_spmd()
+            num_devices = xr.global_runtime_device_count()
+            mesh_shape = (num_devices, 1)
+            device_ids = np.array(range(num_devices))
+            # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
+            mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
+            xs.set_global_mesh(mesh)
+
+            auto_wrap_policy = functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={
+                    Qwen2DecoderLayer
+                },
+            )
+            critic_module = FSDPv2(critic_module, auto_wrap_policy=auto_wrap_policy, shard_output=custom_shard_output_impl)
 
         self.critic_model_config = critic_model_config
 
@@ -522,4 +603,3 @@ class CriticWorker(Worker):
 
         output = output.to("cpu")
         return output
-

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -81,7 +81,6 @@ class ActorRolloutRefWorker(Worker):
 
     def __init__(self, config: DictConfig, role: str):
         super().__init__()
-        breakpoint()
         self.config = config
         self.device_name = get_device_name()
 
@@ -182,7 +181,6 @@ class ActorRolloutRefWorker(Worker):
         if self.rank == 0:
             print_model_size(actor_module)
         
-        breakpoint()
         if self._is_actor:
             xr.use_spmd()
             num_devices = xr.global_runtime_device_count()

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -106,13 +106,7 @@ class ActorRolloutRefWorker(Worker):
                 assert self.config.actor.ppo_mini_batch_size % self.config.actor.ppo_micro_batch_size_per_gpu == 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
                 assert self.config.actor.ppo_mini_batch_size // self.config.actor.ppo_micro_batch_size_per_gpu > 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be larger than ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
             
-            xr.use_spmd()
-            num_devices = xr.global_runtime_device_count()
-            mesh_shape = ("MESH SHAPE", mesh_shape)
-            device_ids = np.array(range(num_devices))
-            # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
-            mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
-            xs.set_global_mesh(mesh)
+
 
         # normalize rollout config
         if self._is_rollout and self.config.rollout.log_prob_micro_batch_size is not None:
@@ -190,6 +184,14 @@ class ActorRolloutRefWorker(Worker):
         
         breakpoint()
         if self._is_actor:
+            xr.use_spmd()
+            num_devices = xr.global_runtime_device_count()
+            mesh_shape = (num_devices, 1)
+            device_ids = np.array(range(num_devices))
+            # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
+            mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
+            xs.set_global_mesh(mesh)
+            
             auto_wrap_policy = functools.partial(
                 transformer_auto_wrap_policy,
                 transformer_layer_cls={

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -75,7 +75,7 @@ def custom_shard_output_impl(output, mesh):
 
     if not torch_xla._XLAC._get_xla_sharding_spec(real_output):
         xs.mark_sharding(
-            real_output, mesh, ("fdsp", None, None))
+            real_output, mesh, ("fsdp", None, None))
 
 def custom_shard_output_impl(output, mesh):
     import torch_xla

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -342,7 +342,7 @@ class ActorRolloutRefWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def generate_sequences(self, prompts: DataProto):
+    def generate_sequences(self, prompts: DataProto, actor_weights=None):
         # Support all hardwares
         prompts = prompts.to(get_torch_device().current_device())
 
@@ -357,7 +357,8 @@ class ActorRolloutRefWorker(Worker):
 
         with _timer("generate_sequences", timing_generate):
             print("ACTOR WEIGHTS IS NONE?")
-            params = self.actor_module_fsdp.state_dict()
+            print(actor_weights)
+            params = actor_weights if actor_weights is not None else self.actor_module_fsdp.state_dict()
             params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
@@ -374,11 +375,11 @@ class ActorRolloutRefWorker(Worker):
         get_torch_device().empty_cache()
         return output
     
-    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def get_state_dict(self, data: DataProto):
         weights = self.actor_module_fsdp.state_dict()
 
-        return data    
+        return weights   
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -46,17 +46,20 @@ from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
 import functools
 from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
 from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.modeling_outputs import TokenClassifierOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
-def shard_output_with_causal_lm(output, mesh):
+def custom_shard_output_impl(output, mesh):
     import torch_xla
     real_output = None
     if isinstance(output, torch.Tensor):
         real_output = output
     elif isinstance(output, CausalLMOutputWithPast):
         real_output = output.logits
+    elif isinstance(output, TokenClassifierOutput):
+          real_output = output.logits
     elif isinstance(output, tuple):
         real_output = output[0] if isinstance(output[0], torch.Tensor) else None
         warnings.warn(
@@ -221,7 +224,7 @@ class ActorRolloutRefWorker(Worker):
                     Qwen2DecoderLayer
                 },
             )
-            actor_module = FSDPv2(actor_module, auto_wrap_policy=auto_wrap_policy, shard_output=shard_output_with_causal_lm)
+            actor_module = FSDPv2(actor_module, auto_wrap_policy=auto_wrap_policy, shard_output=custom_shard_output_impl)
 
         if role == "actor" and optim_config is not None:
             from verl.utils.torch_functional import get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
@@ -350,15 +353,13 @@ class ActorRolloutRefWorker(Worker):
         # perform training
         with Timer(name="update_policy", logger=None) as timer:
             metrics = self.actor.update_policy(data=data)
-        
-        if not self.config.actor.enable_fsdp_xla:
-            delta_time = timer.last
-            global_num_tokens = data.meta_info["global_token_num"]
-            estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
-            metrics["perf/mfu/actor"] = estimated_flops * self.config.actor.ppo_epochs / promised_flops / self.world_size
-            metrics["perf/max_memory_allocated_gb"] = get_torch_device().max_memory_allocated() / (1024**3)
-            metrics["perf/max_memory_reserved_gb"] = get_torch_device().max_memory_reserved() / (1024**3)
-            metrics["perf/cpu_memory_used_gb"] = psutil.virtual_memory().used / (1024**3)
+        # delta_time = timer.last
+        # global_num_tokens = data.meta_info["global_token_num"]
+        # estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
+        # metrics["perf/mfu/actor"] = estimated_flops * self.config.actor.ppo_epochs / promised_flops / self.world_size
+        # metrics["perf/max_memory_allocated_gb"] = get_torch_device().max_memory_allocated() / (1024**3)
+        # metrics["perf/max_memory_reserved_gb"] = get_torch_device().max_memory_reserved() / (1024**3)
+        # metrics["perf/cpu_memory_used_gb"] = psutil.virtual_memory().used / (1024**3)
 
         lr = self.actor_lr_scheduler.get_last_lr()[0]
         metrics["actor/lr"] = lr
@@ -389,8 +390,6 @@ class ActorRolloutRefWorker(Worker):
             else:
                 params = self.actor_module_fsdp.state_dict()
                 params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
-
-            params_rollout = self.actor_module_fsdp.state_dict()
 
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
@@ -555,22 +554,16 @@ class CriticWorker(Worker):
         # some parameters may not in torch_dtype
         critic_module.to(torch_dtype)
 
-        if self.config.enable_fsdp_xla:
-            xr.use_spmd()
-            num_devices = xr.global_runtime_device_count()
-            mesh_shape = (num_devices, 1)
-            device_ids = np.array(range(num_devices))
-            # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
-            mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
-            xs.set_global_mesh(mesh)
+        if self.rank == 0:
+            print_model_size(critic_module)
 
-            auto_wrap_policy = functools.partial(
-                transformer_auto_wrap_policy,
-                transformer_layer_cls={
-                    Qwen2DecoderLayer
-                },
-            )
-            critic_module = FSDPv2(critic_module, auto_wrap_policy=auto_wrap_policy, shard_output=custom_shard_output_impl)
+        auto_wrap_policy = functools.partial(
+            transformer_auto_wrap_policy,
+            transformer_layer_cls={
+                Qwen2DecoderLayer
+            },
+        )
+        critic_module = FSDPv2(critic_module, auto_wrap_policy=auto_wrap_policy, shard_output=custom_shard_output_impl)
 
         self.critic_model_config = critic_model_config
 
@@ -604,6 +597,13 @@ class CriticWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
+        xr.use_spmd()
+        num_devices = xr.global_runtime_device_count()
+        mesh_shape = (num_devices, 1)
+        device_ids = np.array(range(num_devices))
+        # To be noted, the mesh must have an axis named 'fsdp', which the weights and activations will be sharded on.
+        mesh = xs.Mesh(device_ids, mesh_shape, ('fsdp', 'model'))
+        xs.set_global_mesh(mesh)
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
 

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -28,6 +28,7 @@ from omegaconf import DictConfig
 from verl import DataProto
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register, Execute
+from verl.single_controller.base.decorator import Dispatch, register, Execute
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.debug.performance import _timer, reduce_timing
 from verl.utils.device import get_device_name, get_torch_device
@@ -341,7 +342,7 @@ class ActorRolloutRefWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def generate_sequences(self, prompts: DataProto):
+    def generate_sequences(self, prompts: DataProto, actor_weights: dict = None):
         # Support all hardwares
         prompts = prompts.to(get_torch_device().current_device())
 
@@ -355,12 +356,10 @@ class ActorRolloutRefWorker(Worker):
         timing_generate = {}
 
         with _timer("generate_sequences", timing_generate):
-            if self.actor_wg is not None:
-                params = self.actor_wg.get_state_dict()[0]
-            else:
-                params = self.actor_module_fsdp.state_dict()
-                params = convert_weight_keys(params, self.actor_module_fsdp)
-
+            print("ACTOR WEIGHTS IS NONE?")
+            print(actor_weights is None)
+            params = actor_weights if actor_weights is not None else self.actor_module_fsdp.state_dict()
+            params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
             # Create a list to hold the prepared parameters
@@ -376,31 +375,33 @@ class ActorRolloutRefWorker(Worker):
         get_torch_device().empty_cache()
         return output
     
-    @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=True)
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL, execute_mode=Execute.RANK_ZERO)
     def get_state_dict(self):
-        assert self._is_actor
-        params = self.actor_module_fsdp.state_dict()
-        params = convert_weight_keys(params, getattr(self.actor_module_fsdp, "_orig_module", self.actor_module_fsdp))
-        return params
+        return self.actor_module_fsdp.state_dict()
+    
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):
         assert self._is_actor
-        # Support all hardwares
-        data = data.to(get_torch_device().current_device())
-        # we should always recompute old_log_probs when it is HybridEngine
-        data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
-        data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
-        data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
-        data.meta_info["temperature"] = self.config.rollout.temperature
-        # perform recompute log_prob
-        output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
-        output = DataProto.from_dict(
-            tensors={"old_log_probs": output, "entropys": entropys},
-            meta_info={"temperature": self.config.rollout.temperature},
-        )
 
-        output = output.to("cpu")
+        print("RUNNING COMPUTE LOG PROBS")
+
+        output = data
+        # # Support all hardwares
+        # data = data.to(get_torch_device().current_device())
+        # # we should always recompute old_log_probs when it is HybridEngine
+        # data.meta_info["micro_batch_size"] = self.config.rollout.log_prob_micro_batch_size_per_gpu
+        # data.meta_info["max_token_len"] = self.config.rollout.log_prob_max_token_len_per_gpu
+        # data.meta_info["use_dynamic_bsz"] = self.config.rollout.log_prob_use_dynamic_bsz
+        # data.meta_info["temperature"] = self.config.rollout.temperature
+        # # perform recompute log_prob
+        # output, entropys = self.actor.compute_log_prob(data=data, calculate_entropy=True)
+        # output = DataProto.from_dict(
+        #     tensors={"old_log_probs": output, "entropys": entropys},
+        #     meta_info={"temperature": self.config.rollout.temperature},
+        # )
+
+        # output = output.to("cpu")
 
         return output
 

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -384,8 +384,8 @@ class ActorRolloutRefWorker(Worker):
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
 
-        # for k, v in weights.items():
-        #     weights[k] = v.cpu()
+        for k, v in weights.items():
+            weights[k] = v.cpu()
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -358,7 +358,11 @@ class ActorRolloutRefWorker(Worker):
         with _timer("generate_sequences", timing_generate):
             print("ACTOR WEIGHTS IS NONE?")
             print(actor_weights is not None)
-            params = actor_weights.non_tensor_batch["actor_weights"]
+            if actor_weights is not None:
+                params = actor_weights.non_tensor_batch["actor_weights"]
+            else:
+                params = self.actor_module_fsdp.state_dict()
+                params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
             # Create a list to hold the prepared parameters

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -37,16 +37,7 @@ from verl.utils.fs import copy_to_local
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import convert_weight_keys
 from torch.distributed.tensor import DTensor
-import numpy as np
-import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
-from torch_xla.experimental.spmd_fully_sharded_data_parallel import SpmdFullyShardedDataParallel as FSDPv2
-from torch_xla.experimental.spmd_fully_sharded_data_parallel import _prepare_spmd_partition_spec
-from torch_xla.distributed.fsdp.wrap import transformer_auto_wrap_policy
-import functools
-from transformers.models.qwen2.modeling_qwen2 import Qwen2DecoderLayer
-from transformers.modeling_outputs import CausalLMOutputWithPast
-from transformers.modeling_outputs import TokenClassifierOutput
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -107,6 +98,7 @@ class ActorRolloutRefWorker(Worker):
             if self.config.actor.ppo_micro_batch_size_per_gpu is not None:
                 assert self.config.actor.ppo_mini_batch_size % self.config.actor.ppo_micro_batch_size_per_gpu == 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be divisible by ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
                 assert self.config.actor.ppo_mini_batch_size // self.config.actor.ppo_micro_batch_size_per_gpu > 0, f"normalized ppo_mini_batch_size {self.config.actor.ppo_mini_batch_size} should be larger than ppo_micro_batch_size_per_gpu {self.config.actor.ppo_micro_batch_size_per_gpu}"
+            xr.use_spmd()
             
         # normalize rollout config
         if self._is_rollout and self.config.rollout.log_prob_micro_batch_size is not None:

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -377,7 +377,6 @@ class ActorRolloutRefWorker(Worker):
     
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def get_state_dict(self, data: DataProto):
-        breakpoint()
         output = DataProto()
         weights = self.actor_module_fsdp.state_dict()
         for k, v in weights.items():

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -358,7 +358,7 @@ class ActorRolloutRefWorker(Worker):
         with _timer("generate_sequences", timing_generate):
             print("ACTOR WEIGHTS IS NONE?")
             print(actor_weights)
-            params = actor_weights if actor_weights is not None else self.actor_module_fsdp.state_dict()
+            params = self.actor_module_fsdp.state_dict()
             params = convert_weight_keys(params, self.actor_module_fsdp)
             model = self.rollout.inference_engine.llm_engine.model_executor.driver_worker.model_runner.model
 
@@ -377,9 +377,10 @@ class ActorRolloutRefWorker(Worker):
     
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def get_state_dict(self, data: DataProto):
+        breakpoint()
         weights = self.actor_module_fsdp.state_dict()
 
-        return weights   
+        return data   
     
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -383,11 +383,11 @@ class ActorRolloutRefWorker(Worker):
         output = DataProto()
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
-        with open("actor_weights.txt", "w") as file:
-            file.write(wights)
+        with open("actor_weights.txt", "a") as file:
+            file.write(weights)
         for k, v in weights.items():
             weights[k] = v.cpu()
-        with open("actor_weights_cpu.txt", "w") as file:
+        with open("actor_weights_cpu.txt", "a") as file:
             file.write(weights)
         output.non_tensor_batch["actor_weights"] = weights
 

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -383,12 +383,12 @@ class ActorRolloutRefWorker(Worker):
         output = DataProto()
         weights = self.actor_module_fsdp.state_dict()
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
-        with open("/workspaces/logging/actor_weights.txt", "w") as file:
-            json.dump(weights, file)
+        with open("actor_weights.txt", "w") as file:
+            file.write(wights)
         for k, v in weights.items():
             weights[k] = v.cpu()
-        with open("/workspaces/logging/actor_weights_cpu.txt", "w") as file:
-            json.dump(weights, file)
+        with open("actor_weights_cpu.txt", "w") as file:
+            file.write(weights)
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -385,10 +385,10 @@ class ActorRolloutRefWorker(Worker):
         weights = convert_weight_keys(weights, self.actor_module_fsdp)
         with open("actor_weights.txt", "a") as file:
             file.write(str(weights))
-        for k, v in weights.items():
-            weights[k] = v.cpu()
-        with open("actor_weights_cpu.txt", "a") as file:
-            file.write(str(weights))
+        # for k, v in weights.items():
+        #     weights[k] = v.cpu()
+        # with open("actor_weights_cpu.txt", "a") as file:
+        #     file.write(str(weights))
         output.non_tensor_batch["actor_weights"] = weights
 
         return output   

--- a/verl/workers/tpu_workers.py
+++ b/verl/workers/tpu_workers.py
@@ -264,6 +264,9 @@ class ActorRolloutRefWorker(Worker):
     def _build_rollout(self, trust_remote_code=False):
 
         infer_tp = self.config.rollout.tensor_model_parallel_size
+        # assert self.world_size % infer_tp == 0, f"rollout world_size: {self.world_size} is not divisible by infer_tp: {infer_tp}"
+
+        infer_tp = self.config.rollout.tensor_model_parallel_size
         assert self.world_size % infer_tp == 0, f"rollout world_size: {self.world_size} is not divisible by infer_tp: {infer_tp}"
         rollout_name = self.config.rollout.name
         assert rollout_name == "vllm"


### PR DESCRIPTION
## Support both FSDP and single chip RL.

#### Added configurations
* `enable_fsdp_xla` whether or not to enable FSDP
* `fsdp_spmd_config.n_tpus` how many tpu chips to have in the placement group (means how many tpu chips we want to shard across)

####  Modified placement group configurations:
* FSDP via SPMD requires a single process on multiple chips, this means we need to create placement groups with more than just one accelerator inside
* The rollout and actor/critic cannot both be located on the same TPU machine due to `xr.use_spmd()` leading to undefined behaviour for vLLM. Thus when FSDP is enabled, we need to have the placement group strategy set as `SPREAD` in the case where the actor/critic does not take up all TPU chips on a TPU

####  Resource pool modifications:
* Create two resource pools if FSDP is enabled one for rollout and one for actor/critic

####  Ray trainer modifications:
* use a `_get_worker` function to obtain either the `actorrollout` worker for single chip RL or the `actor`/`rollout` worker for FSDP
* Since the rollout is not colocated with the critic anymore, we need to add a case for a non fused worker

#### TPU utils modifications:
* Add a conditional GPU memory logger since enabling SPMD prevents us from using the `xm.get_memory_info()` in Pytroch/XLA 
* Add function that will help shard input data for actor and critic

#### Actor/Critic/Rollout modifications:
* use conditional GPU memory logger
* use the data sharding function

#### TPUworker modifications:
* Add FSDP sharding logic
* add `get_state_dict` function to send weights from actor to rollout

Note: due to a messy rebase there were a few lines of duplicated code that was merged from this PR. Those lines of code have now been removed in a future PR.


How to run this: [guide](https://docs.google.com/presentation/d/1YN9s5hEepTdM_m1tQ_rxj8pX1EG5kThMgspU_kmAy7c/edit?usp=sharing)
